### PR TITLE
use inheritance from `OpenTracing` base classes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# see: http://editorconfig.org/
+
+# stop searching for .editorconfig in parent folders
+root = true
+
+trim_trailing_whitespace = true
+insert_final_newline     = true
+end_of_line              = lf
+
+[*.{js,json}]
+indent_style = space
+indent_size  = 2
+
+[package.json]
+indent_style = space
+indent_size  = 2

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -14,7 +14,7 @@ exports[`Opentracing interface inject (serialize) HTTP Headers should throw with
 
 exports[`Opentracing interface inject (serialize) Text Map should throw an error, because it is unsupported 1`] = `"inject called with unsupported format"`;
 
-exports[`Opentracing interface should be have kind server, client and local  1`] = `"kind option needs to be provided as either \\"local\\", \\"client\\" or \\"server\\""`;
+exports[`Opentracing interface should be have kind server, client and local 1`] = `"kind option needs to be provided as either \\"local\\", \\"client\\" or \\"server\\""`;
 
 exports[`Opentracing interface should fail to init tracer with a malformed kind 1`] = `"kind option needs to be provided as either \\"local\\", \\"client\\" or \\"server\\""`;
 

--- a/src/__tests__/e2e.js
+++ b/src/__tests__/e2e.js
@@ -314,13 +314,13 @@ describe("zipkin-javascript-opentracing", () => {
           ZipkinJavascriptOpentracing.FORMAT_HTTP_HEADERS,
           headers
         );
-        const newSpan = tracer.extract(
+        const newSpanCtx = tracer.extract(
           ZipkinJavascriptOpentracing.FORMAT_HTTP_HEADERS,
           headers
         );
 
-        expect(newSpan.id.spanId).toEqual(span.id._spanId);
-        expect(newSpan.id.traceId).toEqual(span.id.traceId);
+        expect(newSpanCtx.spanId).toEqual(span.id._spanId);
+        expect(newSpanCtx.traceId).toEqual(span.id.traceId);
       });
 
       it("should work with extracting and injecting in a row", () => {

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -72,7 +72,7 @@ describe("Opentracing interface", () => {
     expect(tracer.startSpan).toBeInstanceOf(Function);
   });
 
-  it("should be have kind server, client and local ", () => {
+  it("should be have kind server, client and local", () => {
     expect(() => {
       new Tracer({
         serviceName: "MyService",
@@ -136,6 +136,16 @@ describe("Opentracing interface", () => {
       zipkinTracer.scoped.mock.calls[0][0]();
 
       expect(zipkinTracer.recordBinary).not.toHaveBeenCalled();
+    });
+
+    it("should expose the underlying tracer", () => {
+      const span = tracer.startSpan("my-span-name");
+      expect(span.tracer()).toBeDefined();
+    });
+
+    it("should expose the span context", () => {
+      const span = tracer.startSpan("my-span-name");
+      expect(span.context()).toBeDefined();
     });
 
     it("startSpan should start a span", () => {
@@ -611,16 +621,14 @@ describe("Opentracing interface", () => {
           "x-b3-spanid": "mySpanId",
           "x-b3-sampled": "1"
         };
-        const span = tracer.extract(Tracer.FORMAT_HTTP_HEADERS, httpHeaders);
+        const spanCtx = tracer.extract(Tracer.FORMAT_HTTP_HEADERS, httpHeaders);
         expect(zipkinTracer.scoped).not.toHaveBeenCalled();
         expect(zipkinTracer.recordAnnotation).not.toHaveBeenCalled();
         expect(zipkinTracer.recordServiceName).not.toHaveBeenCalled();
 
-        expect(span.id.traceId.value).toBe("myTraceId");
-        expect(span.id.spanId).toBe("mySpanId");
-        expect(span.id.sampled.value).toBe("1");
-        expect(span.log).toBeInstanceOf(Function);
-        expect(span.finish).toBeInstanceOf(Function);
+        expect(spanCtx.traceId.value).toBe("myTraceId");
+        expect(spanCtx.spanId).toBe("mySpanId");
+        expect(spanCtx.sampled.value).toBe("1");
       });
 
       it("should handle parent spans correctly", () => {
@@ -630,17 +638,15 @@ describe("Opentracing interface", () => {
           "x-b3-parentspanid": "myParentSpanId",
           "x-b3-sampled": "1"
         };
-        const span = tracer.extract(Tracer.FORMAT_HTTP_HEADERS, httpHeaders);
+        const spanCtx = tracer.extract(Tracer.FORMAT_HTTP_HEADERS, httpHeaders);
         expect(zipkinTracer.scoped).not.toHaveBeenCalled();
         expect(zipkinTracer.recordAnnotation).not.toHaveBeenCalled();
         expect(zipkinTracer.recordServiceName).not.toHaveBeenCalled();
 
-        expect(span.id.traceId.value).toBe("myTraceId");
-        expect(span.id.spanId).toBe("mySpanId");
-        expect(span.id.parentId.value).toBe("myParentSpanId");
-        expect(span.id.sampled.value).toBe("1");
-        expect(span.log).toBeInstanceOf(Function);
-        expect(span.finish).toBeInstanceOf(Function);
+        expect(spanCtx.traceId.value).toBe("myTraceId");
+        expect(spanCtx.spanId).toBe("mySpanId");
+        expect(spanCtx.parentId.value).toBe("myParentSpanId");
+        expect(spanCtx.sampled.value).toBe("1");
       });
     });
 


### PR DESCRIPTION
Use proper inheritance from the `OpenTracing` base classes for `Span` and `Tracer` as indicated here: https://github.com/opentracing/opentracing-javascript#opentracing-tracer-implementations

The major change is the usage of `TraceId` as a `span context` which is returned from `Tracer.extract()` instead of a `span`. The unit tests have been adjusted accordingly. And the implementation have been simplified by this.

Since I don't know much about the `zipkin` protocol itself, I was not able to fill in some reasonable implementations for the `baggage` feature of `OpenTracing`.