### PR TITLE
Support OpenTracing span.context()

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -249,6 +249,12 @@ describe("Opentracing interface", () => {
         expect(span.id.sampled).toBeDefined();
       });
 
+      it("should expose its context", () => {
+        const spanContext = span.context();
+        expect(spanContext.toSpanId()).toBe(span.id.spanId);
+        expect(spanContext.toTraceId()).toBe(span.id.traceId);
+      });
+
       it("should log data", () => {
         span.log({ event: "data_received", data: "42" });
 

--- a/src/index.js
+++ b/src/index.js
@@ -172,6 +172,18 @@ function SpanCreator({ tracer, serviceName, kind }) {
       });
     }
 
+    context() {
+      const { spanId, traceId } = this.id;
+      return {
+        toSpanId() {
+          return spanId;
+        },
+        toTraceId() {
+          return traceId;
+        }
+      };
+    }
+
     finish() {
       tracer.scoped(() => {
         // make sure correct id is set


### PR DESCRIPTION
PR for issue https://github.com/DanielMSchmidt/zipkin-javascript-opentracing/issues/98, to support [`span.context()`](https://opentracing-javascript.surge.sh/classes/span.html#context)
