### PR TITLE
Ashish: Add log functionality to tracer

### DIFF
--- a/__mocks__/zipkin.js
+++ b/__mocks__/zipkin.js
@@ -100,6 +100,7 @@ module.exports = {
       };
     }),
     recordAnnotation: jest.fn(),
+    recordMessage: jest.fn(),
     recordBinary: jest.fn(),
     recordServiceName: jest.fn(),
     scoped: jest.fn(cb => process.nextTick(cb)),

--- a/src/__tests__/e2e.js
+++ b/src/__tests__/e2e.js
@@ -180,10 +180,7 @@ describe("zipkin-javascript-opentracing", () => {
 
     it("should record logs", () => {
       const span = tracer.startSpan("My Span");
-      span.log({
-        statusCode: "200",
-        objectId: "42"
-      });
+      span.log("LogMessage");
 
       span.finish();
 
@@ -208,13 +205,9 @@ describe("zipkin-javascript-opentracing", () => {
           "duration"
         ])
       );
-      expect(json[0].annotations.length).toBe(2);
+      expect(json[0].annotations.length).toBe(3);
       expect(json[0].annotations[0].endpoint.serviceName).toBe("my service");
-      expect(json[0].binaryAnnotations.length).toBe(2);
-      expect(json[0].binaryAnnotations[0].key).toBe("statusCode");
-      expect(json[0].binaryAnnotations[0].value).toBe("200");
-      expect(json[0].binaryAnnotations[1].key).toBe("objectId");
-      expect(json[0].binaryAnnotations[1].value).toBe("42");
+      expect(json[0].annotations[0].value).toBe("LogMessage");
       expect(json[0].name).toBe("my span");
     });
   });

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -256,17 +256,23 @@ describe("Opentracing interface", () => {
       });
 
       it("should log data", () => {
-        span.log({ event: "data_received", data: "42" });
+        span.log("data to log");
 
         // should do it in a scope
         expect(zipkinTracer.scoped).toHaveBeenCalled();
         zipkinTracer.scoped.mock.calls[0][0]();
 
-        expect(zipkinTracer.recordBinary).toHaveBeenCalledWith(
-          "event",
-          "data_received"
-        );
-        expect(zipkinTracer.recordBinary).toHaveBeenCalledWith("data", "42");
+        expect(zipkinTracer.recordMessage).toHaveBeenCalledWith("data to log");
+      });
+
+      it("should not log if empty data is passed", () => {
+        span.log();
+
+        // should do it in a scope
+        expect(zipkinTracer.scoped).toHaveBeenCalled();
+        zipkinTracer.scoped.mock.calls[0][0]();
+
+        expect(zipkinTracer.recordMessage).not.toHaveBeenCalled();
       });
 
       it("should use the right id in log", () => {
@@ -276,7 +282,7 @@ describe("Opentracing interface", () => {
 
         zipkinTracer.scoped.mockReset();
         zipkinTracer.setId.mockReset();
-        span.log({ event: "other event" });
+        span.log("other event");
 
         // should do it in a scope
         expect(zipkinTracer.scoped).toHaveBeenCalled();
@@ -285,7 +291,7 @@ describe("Opentracing interface", () => {
         zipkinTracer.scoped.mockReset();
         zipkinTracer.setId.mockReset();
 
-        otherSpan.log({ event: "yet another event" });
+        otherSpan.log("yet another event");
         // should do it in a scope
         expect(zipkinTracer.scoped).toHaveBeenCalled();
         zipkinTracer.scoped.mock.calls[0][0]();

--- a/src/index.js
+++ b/src/index.js
@@ -125,14 +125,13 @@ function SpanCreator({ tracer, serviceName, kind }) {
       }
     }
 
-    log(obj = {}) {
+    log(obj) {
       tracer.scoped(() => {
         // make sure correct id is set
-        tracer.setId(this.id);
-
-        Object.entries(obj).map(([key, value]) => {
-          tracer.recordBinary(key, value);
-        });
+        if (obj) {
+          tracer.setId(this.id);
+          tracer.recordMessage(obj);
+        }
       });
     }
     setTag(key, value) {


### PR DESCRIPTION
this PR adds logging functionality  to the tracer. it sends logs as separate from tags. It add logs in annotation but as binaryAnnotations. 

Issue Solved: https://github.com/DanielMSchmidt/zipkin-javascript-opentracing/issues/102